### PR TITLE
SRAssembler, significantly faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/*.d
 src/*.o
 speedtest/
 demo/reads_data
+demo/x*

--- a/demo/SRAssembler.conf
+++ b/demo/SRAssembler.conf
@@ -18,6 +18,10 @@ e=1
 l=30
 e=0
 
+[Vmatch_contig_vs_reads]
+l=30
+e=2
+
 [GenomeThreader]
 gcmincoverage=10
 prminmatchlen=15

--- a/src/AbyssAssembler.cpp
+++ b/src/AbyssAssembler.cpp
@@ -33,7 +33,7 @@ void AbyssAssembler::do_assembly(int kmer, const vector<Library>& libraries, con
 		if (get_file_size(lib.get_matched_left_read_filename()) == 0) continue;
 		if (lib.get_paired_end()) {
 			string lib_name = "pe" + int2str(lib.get_insert_size());
-			lib_list +=  lib_name + " ";
+			lib_list += lib_name + " ";
 			paired_files += lib_name + "='" + lib.get_matched_left_read_filename() + " " + lib.get_matched_right_read_filename() + "' ";
 		} else
 			single_files += lib.get_matched_left_read_filename() + " ";

--- a/src/AbyssAssembler.cpp
+++ b/src/AbyssAssembler.cpp
@@ -30,13 +30,13 @@ void AbyssAssembler::do_assembly(int kmer, const vector<Library>& libraries, con
 	string single_files = "";
 	for (unsigned int i=0; i<libraries.size();i++){
 		Library lib = libraries[i];
-		if (get_file_size(lib.get_matched_left_read_filename()) == 0) continue;
+		if (get_file_size(lib.get_matched_left_reads_filename()) == 0) continue;
 		if (lib.get_paired_end()) {
 			string lib_name = "pe" + int2str(lib.get_insert_size());
 			lib_list += lib_name + " ";
-			paired_files += lib_name + "='" + lib.get_matched_left_read_filename() + " " + lib.get_matched_right_read_filename() + "' ";
+			paired_files += lib_name + "='" + lib.get_matched_left_reads_filename() + " " + lib.get_matched_right_reads_filename() + "' ";
 		} else
-			single_files += lib.get_matched_left_read_filename() + " ";
+			single_files += lib.get_matched_left_reads_filename() + " ";
 	}
 	if (lib_list != ""){
 		lib_list = "lib='" + lib_list + "'";

--- a/src/Assembler.h
+++ b/src/Assembler.h
@@ -18,7 +18,7 @@ class Assembler {
 public:
 	Assembler(int, string);
 	virtual ~Assembler();
-	//virtual void do_assembly(int kmer, int min_cov, int insert_size, const string& left_read, const string& right_read,  const string& output_file)=0;
+	//virtual void do_assembly(int kmer, int min_cov, int insert_size, const string& left_read, const string& right_read, const string& output_file)=0;
 	virtual void do_assembly(int kmer, const vector<Library>& libraries, const string& output_file)=0;
 	virtual bool is_available()=0;
 	virtual void clean_files(const string& dir)=0;

--- a/src/GeneFinder.h
+++ b/src/GeneFinder.h
@@ -19,7 +19,7 @@ class GeneFinder {
 public:
 	GeneFinder(int, string);
 	virtual ~GeneFinder();
-	virtual void do_gene_finding(const string& genomic_file, const string& species, const Params& params, const string& output_file)=0;
+	virtual void do_gene_finding(const string& genomic_file, const string& species, const Params& params, const string& output_file, const string& protein_output_file)=0;
 	virtual string get_output_summary()=0;
 	virtual string get_program_name()=0;
 	virtual bool is_available()=0;

--- a/src/Library.cpp
+++ b/src/Library.cpp
@@ -84,27 +84,27 @@ void Library::set_right_read(string right_read){
 	this->right_read = right_read;
 }
 
-string Library::get_matched_left_read_filename(){
+string Library::get_matched_left_reads_filename(){
 	return tmp_dir + "/matched_reads_left_" + "lib" + int2str(lib_idx+1) + ".fasta";
 }
 
-string Library::get_matched_left_read_filename(int round){
+string Library::get_matched_left_reads_filename(int round){
 	return tmp_dir + "/matched_reads_left_" + "r" + int2str(round) + "_" + "lib" + int2str(lib_idx+1) + ".fasta";
 }
 
-string Library::get_matched_left_read_filename(int round, int part){
+string Library::get_matched_left_reads_filename(int round, int part){
 	return tmp_dir + "/matched_reads_left_" + "r" + int2str(round) + "_" + "lib" + int2str(lib_idx+1) + "_" + "part" + int2str(part) + ".fasta";
 }
 
-string Library::get_matched_right_read_filename(){
+string Library::get_matched_right_reads_filename(){
 	return tmp_dir + "/matched_reads_right_" + "lib" + int2str(lib_idx+1) + ".fasta";
 }
 
-string Library::get_matched_right_read_filename(int round){
+string Library::get_matched_right_reads_filename(int round){
 	return tmp_dir + "/matched_reads_right_" + "r" + int2str(round) + "_" + "lib" + int2str(lib_idx+1) + ".fasta";
 }
 
-string Library::get_matched_right_read_filename(int round, int part){
+string Library::get_matched_right_reads_filename(int round, int part){
 	if (paired_end)
 		return tmp_dir + "/matched_reads_right_" + "r" + int2str(round) + "_" + "lib" + int2str(lib_idx+1) + "_" + "part" + int2str(part) + ".fasta";
 	return "";

--- a/src/Library.cpp
+++ b/src/Library.cpp
@@ -59,6 +59,7 @@ void Library::set_insert_size(int insert_size){
 }
 
 void Library::set_num_parts(int num_parts){
+	cerr << "Set library " + int2str(this->lib_idx + 1) + " to " + int2str(num_parts) + " parts." << endl;
 	this->num_parts = num_parts;
 }
 

--- a/src/Library.cpp
+++ b/src/Library.cpp
@@ -59,7 +59,7 @@ void Library::set_insert_size(int insert_size){
 }
 
 void Library::set_num_parts(int num_parts){
-	cerr << "Set library " + int2str(this->lib_idx + 1) + " to " + int2str(num_parts) + " parts." << endl;
+	//cerr << "Set library " + int2str(this->lib_idx + 1) + " to " + int2str(num_parts) + " parts." << endl;
 	this->num_parts = num_parts;
 }
 

--- a/src/Library.h
+++ b/src/Library.h
@@ -30,12 +30,12 @@ public:
 	void set_paired_end(bool paired_end);
 	void set_left_read(string left_read);
 	void set_right_read(string right_read);
-	string get_matched_left_read_filename();
-	string get_matched_right_read_filename();
-	string get_matched_left_read_filename(int round);
-	string get_matched_right_read_filename(int round);
-	string get_matched_left_read_filename(int round, int idx);
-	string get_matched_right_read_filename(int round, int idx);
+	string get_matched_left_reads_filename();
+	string get_matched_right_reads_filename();
+	string get_matched_left_reads_filename(int round);
+	string get_matched_right_reads_filename(int round);
+	string get_matched_left_reads_filename(int round, int idx);
+	string get_matched_right_reads_filename(int round, int idx);
 	string get_file_extension();
 	string get_split_file_name(int file_part, int read_direction);
 	string get_read_part_index_name(int file_part, int read_direction);

--- a/src/MPIWrapper.cpp
+++ b/src/MPIWrapper.cpp
@@ -11,15 +11,15 @@
 #include <mpi.h>
 #endif
 
-int get_mpi_code_value(mpi_code code){
-	return 10000000 * code.action + 100000 * code.value1 + 100* code.value2 + code.value3;
+unsigned long get_mpi_code_value(mpi_code code){
+	return 100000000 * code.action + 1000000 * code.value1 + 100* code.value2 + code.value3;
 }
 
 mpi_code get_mpi_code(int code_value){
 	mpi_code code;
-	code.action = code_value / 10000000;
-	code.value1 = code_value / 100000 % 100;
-	code.value2 = code_value /100 % 1000;;
+	code.action = code_value / 100000000;
+	code.value1 = code_value / 1000000 % 100;
+	code.value2 = code_value / 100 % 10000;;
 	code.value3 = code_value % 100;
 	return code;
 }

--- a/src/MPIWrapper.h
+++ b/src/MPIWrapper.h
@@ -22,7 +22,7 @@ void mpi_receive(char* msg, int& from );
 void mpi_send( const int& code, const int& to );
 void mpi_bcast(const int& code);
 void mpi_receive( int& code, int& from );
-int get_mpi_code_value(mpi_code code);
+unsigned long get_mpi_code_value(mpi_code code);
 mpi_code get_mpi_code(int code_value);
 void mpi_init(int argc, char * argv[] );
 int mpi_get_rank();

--- a/src/SOAPDenovoAssembler.cpp
+++ b/src/SOAPDenovoAssembler.cpp
@@ -36,27 +36,27 @@ void SOAPDenovoAssembler::do_assembly(int kmer, const vector<Library>& libraries
 
 	for (unsigned int i=0; i<libraries.size();i++){
 		Library lib = libraries[i];
-		if (get_file_size(lib.get_matched_left_read_filename()) == 0) continue;
+		if (get_file_size(lib.get_matched_left_reads_filename()) == 0) continue;
 		outFile << "[LIB]" << endl;
 		outFile << "asm_flags=3" << endl;
 		outFile << "rank=" << (i+1) << endl;
 		if (lib.get_paired_end()) {
 			outFile << "avg_ins=" << lib.get_insert_size() << endl;
 			//if (lib.get_format() == FORMAT_FASTQ) {
-				//outFile << "q1=" << lib.get_matched_left_read_filename() << endl;
-				//outFile << "q2=" << lib.get_matched_right_read_filename() << endl;
+				//outFile << "q1=" << lib.get_matched_left_reads_filename() << endl;
+				//outFile << "q2=" << lib.get_matched_right_reads_filename() << endl;
 			//} else {
-			outFile << "f1=" << lib.get_matched_left_read_filename() << endl;
-			outFile << "f2=" << lib.get_matched_right_read_filename() << endl;
+			outFile << "f1=" << lib.get_matched_left_reads_filename() << endl;
+			outFile << "f2=" << lib.get_matched_right_reads_filename() << endl;
 			//}
 			if (lib.get_reversed()) {
 				outFile << "reverse_seq=1" << endl;
 			}
 		} else {
 			//if (lib.get_format() == FORMAT_FASTQ)
-				//outFile << "q=" << lib.get_matched_left_read_filename() << endl;
+				//outFile << "q=" << lib.get_matched_left_reads_filename() << endl;
 			//else
-				outFile << "f=" << lib.get_matched_left_read_filename() << endl;
+				outFile << "f=" << lib.get_matched_left_reads_filename() << endl;
 		}
 	}
 	outFile.close();

--- a/src/SRAssembler.cpp
+++ b/src/SRAssembler.cpp
@@ -647,14 +647,14 @@ int SRAssembler::do_alignment(int round, int lib_idx, int read_part) {
 		if (lib.get_paired_end())
 			aligner->do_alignment(get_contigs_index_name(round), get_type(round), get_match_length(round), get_mismatch_allowed(round), lib.get_split_file_name(read_part, RIGHT_READ), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		ret = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
-		save_mapped_reads(round);
+		//save_mapped_reads(round);
 		return ret;
 	} else {
 		aligner->do_alignment(lib.get_read_part_index_name(read_part, LEFT_READ), get_type(round), get_match_length(round), get_mismatch_allowed(round), get_masked_query_fasta_file_name(round), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		if (lib.get_paired_end())
 			aligner->do_alignment(lib.get_read_part_index_name(read_part, RIGHT_READ), get_type(round), get_match_length(round), get_mismatch_allowed(round), get_masked_query_fasta_file_name(round), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		ret = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
-		save_mapped_reads(round);
+		//save_mapped_reads(round);
 		return ret;
 	}
 }

--- a/src/SRAssembler.cpp
+++ b/src/SRAssembler.cpp
@@ -439,7 +439,7 @@ int SRAssembler::count_preprocessed_reads(int lib_idx){
 	// This uses a system call to count the lines in all the fasta files in the split reads directory
 	string cmd = "wc -l " + data_dir + "/lib" + int2str(lib_idx+1) + "/*part*.fasta | tail -n 1 | cut -d' ' -f3";
 	logger->debug(cmd);
-	return str2int(run_shell_command_with_return(cmd));
+	return str2int(run_shell_command_with_return(cmd)) / 2;
 }
 
 // As far as I can tell this produces interleaved FASTA and interleaved FASTQ files from the split files produced by the library's do_split_files() function.
@@ -800,8 +800,11 @@ void SRAssembler::merge_mapped_files(int round){
 int SRAssembler::get_total_read_count(int round){
 	int count = 0;
 	for (unsigned short int lib_idx=0; lib_idx< this->libraries.size();lib_idx++) {
-		//count += get_read_count(this->libraries[lib_idx].get_matched_left_read_filename(), this->libraries[lib_idx].get_format());
-		count += get_read_count(this->libraries[lib_idx].get_matched_left_read_filename(), FORMAT_FASTA);
+		Library lib = this->libraries[lib_idx];
+		count += get_read_count(lib.get_matched_left_read_filename(), FORMAT_FASTA);
+		if (lib.get_paired_end()) {
+			count += get_read_count(lib.get_matched_right_read_filename(), FORMAT_FASTA);
+		}
 	}
 
 	return count;

--- a/src/SRAssembler.cpp
+++ b/src/SRAssembler.cpp
@@ -523,7 +523,6 @@ void SRAssembler::mask_contigs(int round){
 string SRAssembler:: get_query_fasta_file_name_masked(int round){
 	if (round > 1){
 		if (assembly_round < round) {
-			mask_contigs(round-1);
 			string masked_fasta = get_contig_file_name(round-1) + ".masked";
 			return masked_fasta;
 		} else {
@@ -571,13 +570,15 @@ int SRAssembler::do_alignment(int round, int lib_idx, int read_part) {
 	//TODO we read this parameter file A LOT. We should import the parameters for each program_name once.
 	Params params = this->read_param_file(program_name);
 	int new_read_count;
-	if (round == 1) { // Reads as queries are necessary when searching against a protein.
+	// Reads as queries are necessary when searching against a protein.
+	if (round == 1) {
 		aligner->do_alignment(get_contigs_index_name(round), get_type(round), get_match_length(round), get_mismatch_allowed(round), lib.get_split_file_name(read_part, LEFT_READ), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		if (lib.get_paired_end())
 			aligner->do_alignment(get_contigs_index_name(round), get_type(round), get_match_length(round), get_mismatch_allowed(round), lib.get_split_file_name(read_part, RIGHT_READ), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		new_read_count = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
 		//save_mapped_reads(round);
 		return new_read_count;
+	// After round 1 we use the masked contig file as the query
 	} else {
 		aligner->do_alignment(lib.get_read_part_index_name(read_part, LEFT_READ), get_type(round), get_match_length(round), get_mismatch_allowed(round), get_query_fasta_file_name_masked(round), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		if (lib.get_paired_end())

--- a/src/SRAssembler.cpp
+++ b/src/SRAssembler.cpp
@@ -442,87 +442,6 @@ int SRAssembler::count_preprocessed_reads(int lib_idx){
 	return str2int(run_shell_command_with_return(cmd)) / 2;
 }
 
-// As far as I can tell this produces interleaved FASTA and interleaved FASTQ files from the split files produced by the library's do_split_files() function.
-//void SRAssembler::preprocess_read_part(int lib_idx, int read_part){
-	//Library lib = this->libraries[lib_idx];
-
-	//logger->info("preprocessing lib " + int2str(lib_idx + 1) + ", reads file (" + int2str(read_part) + "/" + int2str(lib.get_num_parts()) + ")");
-	//string suffix = int2str(read_part, 10); // Setting suffix length to 10 for now.
-	//string left_src_read = lib.get_split_read_prefix(lib.get_left_read()) + suffix;
-	//string right_src_read = "";
-	//if (lib.get_paired_end())
-		//right_src_read = lib.get_split_read_prefix(lib.get_right_read()) + suffix;
-	//ifstream left_file(left_src_read.c_str());
-	//ifstream right_file;
-	//if (lib.get_paired_end()){
-		//right_file.open(right_src_read.c_str(), ios_base::in);
-	//}
-	//string left_header = "";
-	//string right_header = "";
-	//string left_seq = "";
-	//string right_seq = "";
-	//string left_qual = "";
-	//string right_qual = "";
-	//string plus;
-	//ofstream split_read_fasta_file;
-	//ofstream split_read_fastq_file; // Shouldn't need this
-	//split_read_fasta_file.open(lib.get_split_file_name(read_part, FORMAT_FASTA).c_str(), ios_base::out);
-	//if (lib.get_format() == FORMAT_FASTQ)
-		//split_read_fastq_file.open(lib.get_split_file_name(read_part, FORMAT_FASTQ).c_str(), ios_base::out);
-	//while (getline(left_file, left_header)) {
-		//// get read data point, which includes 4 lines
-		//string lead_chr = (lib.get_format() == FORMAT_FASTQ)? "@" : ">";
-		//if (left_header.substr(0,1) == lead_chr){
-		 ////save left-end reads
-			//getline(left_file, left_seq);
-			//if (lib.get_format() == FORMAT_FASTQ) {
-				//getline(left_file, plus);
-				//getline(left_file, left_qual);
-			//}
-			//if (lib.get_paired_end()){
-				 ////save right-end reads
-				 //while (getline(right_file, right_header))
-					 //if (right_header.substr(0,1) == lead_chr)
-						 //break;
-				 //getline(right_file, right_seq);
-				 //if (lib.get_format() == FORMAT_FASTQ) {
-					 //getline(right_file, plus);
-					 //getline(right_file, right_qual);
-				 //}
-			//}
-			//if (lib.get_format() == FORMAT_FASTQ) {
-				//split_read_fastq_file << left_header << endl
-									  //<< left_seq << endl
-									  //<< "+" << endl
-									  //<< left_qual << endl;
-			//}
-			//split_read_fasta_file << ">" << left_header.substr(1) << endl << left_seq << endl;
-			//if (lib.get_paired_end()){
-				//if (lib.get_format() == FORMAT_FASTQ) {
-					//split_read_fastq_file << right_header << endl
-								 //<< right_seq << endl
-								 //<< "+" << endl
-								 //<< right_qual << endl;
-				//}
-				//split_read_fasta_file << ">" << right_header.substr(1) << endl << right_seq << endl;
-			//}
-		 //}
-	//}
-	//split_read_fasta_file.close();
-	//if (lib.get_format() == FORMAT_FASTQ)
-		//split_read_fastq_file.close();
-	//left_file.close();
-	//if (lib.get_paired_end())
-		//right_file.close();
-	//string cmd = "rm " + left_src_read + " " + right_src_read;
-	//run_shell_command(cmd);
-	//// Create the Vmatch mkvtree indexes
-	//Aligner* aligner = get_aligner(0);  // Round 0 means DNA Aligner
-	//// create_index(index_name, dna or protein, fasta_file_name)
-	//aligner->create_index(lib.get_read_part_index_name(read_part), "dna", lib.get_split_file_name(read_part, FORMAT_FASTA));
-//}
-
-// Interleaved reads are totally unneccessary
 void SRAssembler::preprocess_read_part(int lib_idx, int read_part){
 	Library lib = this->libraries[lib_idx];
 	logger->info("preprocessing lib " + int2str(lib_idx + 1) + ", reads file (" + int2str(read_part) + "/" + int2str(lib.get_num_parts()) + ")");
@@ -533,7 +452,6 @@ void SRAssembler::preprocess_read_part(int lib_idx, int read_part){
 		right_read_file = lib.get_split_read_prefix(lib.get_right_read()) + suffix;
 	// Create the Vmatch mkvtree indexes
 	Aligner* aligner = get_aligner(0);  // Round 0 means DNA Aligner
-	// create_index(index_name, dna or protein, fasta_file_name)
 	// Creating both indices in one function is not maximally efficient when using a lot of processors, but it's not terrible.
 	aligner->create_index(lib.get_read_part_index_name(read_part, LEFT_READ), "dna", left_read_file);
 	if (lib.get_paired_end())
@@ -607,7 +525,6 @@ string SRAssembler:: get_query_fasta_file_name_masked(int round){
 		if (assembly_round < round) {
 			mask_contigs(round-1);
 			string masked_fasta = get_contig_file_name(round-1) + ".masked";
-			//run_shell_command("printf '\e[38;5;002mUSING MASKED FASTA FOR INDEX\e[0m\n'");
 			return masked_fasta;
 		} else {
 			string joined_file = tmp_dir + "/matched_reads_joined.fasta";
@@ -650,24 +567,24 @@ int SRAssembler::do_alignment(int round, int lib_idx, int read_part) {
 	} else {
 		program_name += "_extend_contig";
 	}
-	logger->info("... using Vmatch criteria: " + program_name);
+	//logger->info("... using Vmatch criteria: " + program_name);
 	//TODO we read this parameter file A LOT. We should import the parameters for each program_name once.
 	Params params = this->read_param_file(program_name);
-	int ret;
+	int new_read_count;
 	if (round == 1) { // Reads as queries are necessary when searching against a protein.
 		aligner->do_alignment(get_contigs_index_name(round), get_type(round), get_match_length(round), get_mismatch_allowed(round), lib.get_split_file_name(read_part, LEFT_READ), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		if (lib.get_paired_end())
 			aligner->do_alignment(get_contigs_index_name(round), get_type(round), get_match_length(round), get_mismatch_allowed(round), lib.get_split_file_name(read_part, RIGHT_READ), params, get_vmatch_output_filename(round, lib_idx, read_part));
-		ret = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
+		new_read_count = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
 		//save_mapped_reads(round);
-		return ret;
+		return new_read_count;
 	} else {
 		aligner->do_alignment(lib.get_read_part_index_name(read_part, LEFT_READ), get_type(round), get_match_length(round), get_mismatch_allowed(round), get_query_fasta_file_name_masked(round), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		if (lib.get_paired_end())
 			aligner->do_alignment(lib.get_read_part_index_name(read_part, RIGHT_READ), get_type(round), get_match_length(round), get_mismatch_allowed(round), get_query_fasta_file_name_masked(round), params, get_vmatch_output_filename(round, lib_idx, read_part));
-		ret = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
+		new_read_count = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
 		//save_mapped_reads(round);
-		return ret;
+		return new_read_count;
 	}
 }
 

--- a/src/SRAssembler.cpp
+++ b/src/SRAssembler.cpp
@@ -639,24 +639,20 @@ int SRAssembler::do_alignment(int round, int lib_idx, int read_part) {
 		program_name += "_extend_contig";
 	}
 	logger->info("... using Vmatch criteria: " + program_name);
+	//TODO we read this parameter file A LOT. We should import the parameters for each program_name once.
 	Params params = this->read_param_file(program_name);
 	int ret;
 	if (round == 1) { // Reads as queries are necessary when searching against a protein.
-		// VmatchAligner::do_alignment(index_name, type, match_length, mismatch_allowed, query_file, params, output_file)
 		aligner->do_alignment(get_contigs_index_name(round), get_type(round), get_match_length(round), get_mismatch_allowed(round), lib.get_split_file_name(read_part, LEFT_READ), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		if (lib.get_paired_end())
 			aligner->do_alignment(get_contigs_index_name(round), get_type(round), get_match_length(round), get_mismatch_allowed(round), lib.get_split_file_name(read_part, RIGHT_READ), params, get_vmatch_output_filename(round, lib_idx, read_part));
-		// Change to always look in FASTA reads file as source.
 		ret = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
 		save_mapped_reads(round);
 		return ret;
 	} else {
-		// VmatchAligner::do_alignment(index_name, type, match_length, mismatch_allowed, query_file, params, output_file)
 		aligner->do_alignment(lib.get_read_part_index_name(read_part, LEFT_READ), get_type(round), get_match_length(round), get_mismatch_allowed(round), get_masked_query_fasta_file_name(round), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		if (lib.get_paired_end())
 			aligner->do_alignment(lib.get_read_part_index_name(read_part, RIGHT_READ), get_type(round), get_match_length(round), get_mismatch_allowed(round), get_masked_query_fasta_file_name(round), params, get_vmatch_output_filename(round, lib_idx, read_part));
-		// VmatchAligner::parse_output(output_file, mapped_reads, read_part, read_index out_left_read, out_right_read)
-		// Need a way to get read indexes
 		ret = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
 		save_mapped_reads(round);
 		return ret;
@@ -858,12 +854,13 @@ Assembly_stats SRAssembler::get_assembly_stats(int round, int k) {
 }
 
 void SRAssembler::save_mapped_reads(int round){
-	//run_shell_command("printf '\e[38;5;002m" "save_mapped_reads INVOKED" "\e[0m\n'");
+	logger->debug("save_mapped_reads INVOKED");
 	string mapped_file = get_mapped_reads_file_name(round);
 	ofstream mapped_file_stream(mapped_file.c_str());
 	for (unordered_set<string>::iterator it = mapped_reads.begin();it != mapped_reads.end(); ++it)
 		 mapped_file_stream << *it << endl;
 	mapped_file_stream.close();
+	logger->debug("save_mapped_reads FINISHED");
 }
 
 void SRAssembler::load_mapped_reads(int round){

--- a/src/SRAssembler.cpp
+++ b/src/SRAssembler.cpp
@@ -856,6 +856,9 @@ int main(int argc, char * argv[] ) {
 	}
 	finalized();
 	if (rank == 0) {
+		string cmd = "rm -rf /dev/shm/SRAssembler" + int2str(start_time);
+		srassembler->get_logger()->debug(cmd);
+		run_shell_command(cmd);
 		string str = "Execution time: " + int2str(time(0) - start_time) + " seconds";
 		srassembler->get_logger()->info(str);
 	}

--- a/src/SRAssembler.cpp
+++ b/src/SRAssembler.cpp
@@ -516,7 +516,8 @@ void SRAssembler::mask_contigs(int round){
 	string contig_file;
 	contig_file = get_contig_file_name(round);
 	string masked_file = contig_file + ".masked";
-	cmd = "dustmasker -in " + contig_file + " -outfmt fasta -out - | sed '/^[^>]/s/[a-z]/N/g' > " + masked_file;
+	// Sed command replaces lowercase letters NOT in the header with capital Ns. AWK command converts FASTA to single-line.
+	cmd = "dustmasker -in " + contig_file + " -outfmt fasta -out - | sed '/^[^>]/s/[a-z]/N/g' | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' > " + masked_file;
 	run_shell_command(cmd);
 }
 

--- a/src/SRAssembler.cpp
+++ b/src/SRAssembler.cpp
@@ -576,7 +576,7 @@ int SRAssembler::do_alignment(int round, int lib_idx, int read_part) {
 		aligner->do_alignment(get_contigs_index_name(round), get_type(round), get_match_length(round), get_mismatch_allowed(round), lib.get_split_file_name(read_part, LEFT_READ), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		if (lib.get_paired_end())
 			aligner->do_alignment(get_contigs_index_name(round), get_type(round), get_match_length(round), get_mismatch_allowed(round), lib.get_split_file_name(read_part, RIGHT_READ), params, get_vmatch_output_filename(round, lib_idx, read_part));
-		new_read_count = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
+		new_read_count = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_reads_filename(round, read_part), lib.get_matched_right_reads_filename(round, read_part));
 		//save_mapped_reads(round);
 		return new_read_count;
 	// After round 1 we use the masked contig file as the query
@@ -584,7 +584,7 @@ int SRAssembler::do_alignment(int round, int lib_idx, int read_part) {
 		aligner->do_alignment(lib.get_read_part_index_name(read_part, LEFT_READ), get_type(round), get_match_length(round), get_mismatch_allowed(round), get_query_fasta_file_name_masked(round), params, get_vmatch_output_filename(round, lib_idx, read_part));
 		if (lib.get_paired_end())
 			aligner->do_alignment(lib.get_read_part_index_name(read_part, RIGHT_READ), get_type(round), get_match_length(round), get_mismatch_allowed(round), get_query_fasta_file_name_masked(round), params, get_vmatch_output_filename(round, lib_idx, read_part));
-		new_read_count = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_read_filename(round, read_part), lib.get_matched_right_read_filename(round, read_part));
+		new_read_count = aligner->parse_output(get_vmatch_output_filename(round, lib_idx, read_part), mapped_reads, read_part, lib.get_read_part_index_name(read_part, LEFT_READ), lib.get_read_part_index_name(read_part, RIGHT_READ), lib.get_matched_left_reads_filename(round, read_part), lib.get_matched_right_reads_filename(round, read_part));
 		//save_mapped_reads(round);
 		return new_read_count;
 	}
@@ -693,7 +693,7 @@ void SRAssembler::merge_mapped_files(int round){
 		Library lib = this->libraries[lib_idx];
 		logger->debug("Now merging component matching reads files ...");
 		string left_files = tmp_dir + "/matched_reads_left_" + "r" + int2str(round) + "_" + "lib" + int2str(lib_idx + 1) + "_part*";
-		string cmd = "cat " + left_files + " >> " + lib.get_matched_left_read_filename();
+		string cmd = "cat " + left_files + " >> " + lib.get_matched_left_reads_filename();
 		logger->debug(cmd);
 		run_shell_command(cmd);
 		//RM HERE
@@ -703,7 +703,7 @@ void SRAssembler::merge_mapped_files(int round){
 
 		if (lib.get_paired_end()) {
 			string right_files = tmp_dir + "/matched_reads_right_" + "r" + int2str(round) + "_" + "lib" + int2str(lib_idx + 1) + "_part*";
-			cmd = "cat " + right_files + " >> " + lib.get_matched_right_read_filename();
+			cmd = "cat " + right_files + " >> " + lib.get_matched_right_reads_filename();
 			logger->debug(cmd);
 			run_shell_command(cmd);
 			//RM HERE
@@ -712,9 +712,9 @@ void SRAssembler::merge_mapped_files(int round){
 			run_shell_command(cmd);
 		}
 		if (round > 1) {
-			run_shell_command("cp " + lib.get_matched_left_read_filename() + " " + lib.get_matched_left_read_filename(round));
+			run_shell_command("cp " + lib.get_matched_left_reads_filename() + " " + lib.get_matched_left_reads_filename(round));
 			if (lib.get_paired_end())
-				run_shell_command("cp " + lib.get_matched_right_read_filename() + " " + lib.get_matched_right_read_filename(round));
+				run_shell_command("cp " + lib.get_matched_right_reads_filename() + " " + lib.get_matched_right_reads_filename(round));
 		}
 	}
 	//RM HERE
@@ -728,9 +728,9 @@ int SRAssembler::get_total_read_count(int round){
 	int count = 0;
 	for (unsigned short int lib_idx=0; lib_idx< this->libraries.size();lib_idx++) {
 		Library lib = this->libraries[lib_idx];
-		count += get_read_count(lib.get_matched_left_read_filename(), FORMAT_FASTA);
+		count += get_read_count(lib.get_matched_left_reads_filename(), FORMAT_FASTA);
 		if (lib.get_paired_end()) {
-			count += get_read_count(lib.get_matched_right_read_filename(), FORMAT_FASTA);
+			count += get_read_count(lib.get_matched_right_reads_filename(), FORMAT_FASTA);
 		}
 	}
 

--- a/src/SRAssembler.cpp
+++ b/src/SRAssembler.cpp
@@ -236,6 +236,7 @@ int SRAssembler::init(int argc, char * argv[], int rank, int mpiSize) {
 		return -1;
 	}
 	tmp_dir = out_dir + "/tmp";
+	dump_dir = "/dev/shm/SRAssembler" + int2str(time(0));
 	if (data_dir == "")
 		data_dir = out_dir + "/" + READS_DATA;
 	preprocessed_exist = file_exists(data_dir);
@@ -330,6 +331,7 @@ int SRAssembler::init(int argc, char * argv[], int rank, int mpiSize) {
 	return 0;
 }
 
+//TODO this should read through one time and store all of the potential parameters so that we aren't always rereading the file
 Params SRAssembler::read_param_file(string program_name) {
 	ifstream param_file(this->param_file.c_str());
 	string line;
@@ -685,7 +687,7 @@ int SRAssembler::get_mismatch_allowed(int round) {
 }
 
 string SRAssembler::get_vmatch_output_filename(int round, int lib_idx, int read_part){
-	return tmp_dir + "/vmatch_" + "r" + int2str(round) + "_" + "lib" + int2str(lib_idx+1) + "_" + "part" + int2str(read_part);
+	return dump_dir + "/vmatch_" + "r" + int2str(round) + "_" + "lib" + int2str(lib_idx+1) + "_" + "part" + int2str(read_part);
 }
 
 void SRAssembler::merge_mapped_files(int round){

--- a/src/SRAssembler.h
+++ b/src/SRAssembler.h
@@ -37,7 +37,7 @@ class SRAssembler {
 public:
 	SRAssembler();
 	virtual ~SRAssembler();
-	virtual int init(int argc, char * argv[], int rank, int mpiSize);
+	virtual int init(int argc, char * argv[], int rank, int mpiSize, const int start_time);
 	virtual void do_preprocessing()=0;
 	virtual void do_walking()=0;
 	virtual void show_usage()=0;
@@ -112,7 +112,7 @@ protected:
 	bool preprocessed_exist;
 	std::string library_file;
 	std::string tmp_dir;
-	std::string dump_dir;
+	std::string mem_dir;
 	std::string intermediate_dir;
 	std::string data_dir;
 	std::string results_dir;
@@ -120,6 +120,7 @@ protected:
 	std::string param_file;
 	std::string spliced_alignment_output_file;
 	std::string gene_finding_output_file;
+	std::string gene_finding_output_protein_file;
 	std::string usage;
 	std::string final_scaf_file;
 	std::string final_contig_file;

--- a/src/SRAssembler.h
+++ b/src/SRAssembler.h
@@ -112,6 +112,7 @@ protected:
 	bool preprocessed_exist;
 	std::string library_file;
 	std::string tmp_dir;
+	std::string dump_dir;
 	std::string intermediate_dir;
 	std::string data_dir;
 	std::string results_dir;

--- a/src/SRAssembler.h
+++ b/src/SRAssembler.h
@@ -54,7 +54,8 @@ protected:
 	void create_index(int round);
 	std::string get_contigs_index_name(int round);
 	std::string get_query_fasta_file_name(int round);
-	std::string get_masked_query_fasta_file_name(int round);
+	void mask_contigs(int round);
+	std::string get_query_fasta_file_name_masked(int round);
 	std::string get_contig_file_name(int round);
 	std::string get_mapped_reads_file_name(int round);
 	std::string get_vmatch_output_filename(int round, int lib_idx, int idx);

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -203,7 +203,7 @@ void SRAssemblerMaster::do_preprocessing(){
 		// File splitting is handled by the actual library. It does not seem to take file type into acount.
 		if (lib->get_paired_end() && mpiSize > 2){
 			send_code(1, ACTION_SPLIT, lib_index, 1, 0);
-			system("sleep 0.5");
+			//system("sleep 0.5");
 			send_code(2, ACTION_SPLIT, lib_index, 2, 0);
 			mpi_receive(code_value, from);
 			mpi_receive(code_value, from);
@@ -348,14 +348,14 @@ void SRAssemblerMaster::do_walking(){
 			// If not parallelized, start a new alignment every 1/2 second?
 			if (mpiSize == 1){
 				for (read_part=1; read_part<=lib.get_num_parts(); read_part++){
-					sleep(0.5);
+					//sleep(0.5);
 					new_reads_count += do_alignment(round, lib_idx, read_part);
 				}
 			} else {
 				// If there are more split read files than processors
 				if (lib.get_num_parts() < mpiSize){
 					for (read_part=1; read_part<=lib.get_num_parts(); read_part++){
-						sleep(0.5);
+						//sleep(0.5);
 						send_code(read_part, ACTION_ALIGNMENT, round, read_part, lib_idx);
 					}
 					while(completed < lib.get_num_parts()){
@@ -368,7 +368,7 @@ void SRAssemblerMaster::do_walking(){
 				// If there are fewer split read files than processors
 				} else {
 					for (read_part=1;read_part<mpiSize;read_part++){
-						sleep(0.5);
+						//sleep(0.5);
 						send_code(read_part, ACTION_ALIGNMENT, round, read_part, lib_idx);
 					}
 					while (completed < lib.get_num_parts()){
@@ -605,7 +605,7 @@ int SRAssemblerMaster::do_assembly(int round) {
 	} else {
 		if (total_k < mpiSize-1){
 			for (i=1; i<=total_k; i++){
-				sleep(0.5);
+				//sleep(0.5);
 				send_code(i, ACTION_ASSEMBLY, round, start_k + (i-1)*step_k, 0);
 			}
 			while(completed < total_k){
@@ -615,7 +615,7 @@ int SRAssemblerMaster::do_assembly(int round) {
 		}
 		else {
 			for (i=1;i<mpiSize;i++){
-				sleep(0.5);
+				//sleep(0.5);
 				send_code(i, ACTION_ASSEMBLY, round, start_k + (i-1)*step_k, 0);
 			}
 			while(completed < total_k){

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -878,16 +878,8 @@ void SRAssemblerMaster::process_long_contigs(int round, int k) {
 			}
 		}
 	}
-	// For right now masking is done by NCBI's dustmasker.
-	//TODO This should be more modular
 	//TODO Masking is happening before cleaning in cleaning rounds.
-	string cmd;
-	string contig_file;
-	contig_file = get_contig_file_name(round);
-	string masked_file = contig_file + ".masked";
-	//cmd = "printf '\e[38;5;002mPROCESS_LONG_CONTIGS\e[0m\n'; dustmasker -in " + contig_file + " -outfmt fasta -out - | sed '/^[^>]/s/[a-z]/N/g' > " + masked_file;
-	cmd = "dustmasker -in " + contig_file + " -outfmt fasta -out - | sed '/^[^>]/s/[a-z]/N/g' > " + masked_file;
-	run_shell_command(cmd);
+	//mask_contigs(round);
 }
 
 void SRAssemblerMaster::remove_hit_contigs(vector<string> &contig_list, int round){

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -175,18 +175,16 @@ void SRAssemblerMaster::do_preprocessing(){
 	for (unsigned lib_index=0;lib_index<this->libraries.size();lib_index++) {
 		Library* lib = &this->libraries[lib_index];
 		lib->set_num_parts(1);
-		// test if files are generated before
+		// test if split files have been generated
 		if (file_exists(lib->get_split_file_name(1, LEFT_READ))){
 			//long library_read_count = get_read_count(lib->get_left_read(), lib->get_format()) + get_read_count(lib->get_right_read(), lib->get_format());
-			long split_read_count = count_preprocessed_reads(lib_index);
-			logger->debug("split_read_count: " + int2str(split_read_count));
+			//long split_read_count = count_preprocessed_reads(lib_index);
+			//logger->debug("split_read_count: " + int2str(split_read_count));
 			lib->set_num_parts(get_file_count(lib->get_split_read_prefix(lib->get_left_read()) + "*.fasta"));
-			logger->debug("split_files_count: " + int2str(lib->get_num_parts()));
 			// Test if split reads have been indexed
 			if (file_exists(lib->get_read_part_index_name(lib->get_num_parts(), LEFT_READ) + ".skp")){
 				logger->info("Using previously split files for read library " + int2str(lib_index+1));
 				broadcast_code(ACTION_TOTAL_PARTS, lib_index, lib->get_num_parts(), 0);
-				//broadcast_code(ACTION_EXIT, 0, 0);
 				continue;
 			}
 		}
@@ -218,7 +216,6 @@ void SRAssemblerMaster::do_preprocessing(){
 		}
 		lib->set_num_parts(get_file_count(lib->get_split_read_prefix(lib->get_left_read()) + "*.fasta"));
 		logger->info("We have " + int2str(lib->get_num_parts()) +" split files");
-
 		broadcast_code(ACTION_TOTAL_PARTS, lib_index, lib->get_num_parts(), 0);
 		int completed = 0;
 

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -336,7 +336,9 @@ void SRAssemblerMaster::do_walking(){
 			create_index(1);
 		} else {
 		// Mask the previous round's contigs for later searches
-			mask_contigs(round-1);
+			if (assembly_round < round) {
+				mask_contigs(round-1);
+			}
 		}
 
 		// For each library
@@ -928,7 +930,9 @@ void SRAssemblerMaster::remove_hit_contigs(vector<string> &contig_list, int roun
 void SRAssemblerMaster::remove_no_hit_contigs(const string& vmatch_outfile, int round){
 	logger->debug("remove contigs without hits against query sequences in round " + int2str(round));
 	string contig_file = get_contig_file_name(round);
-	cmd = "bash -c \"vseqselect -seqnum " + vmatch_outfile + " " + tmp_dir + "\cindex\" | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' >> " + contig_file;
+	string cmd = "bash -c \"vseqselect -seqnum " + vmatch_outfile + " " + tmp_dir + "/cindex\" | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' >> " + contig_file;
+	logger->debug(cmd);
+	run_shell_command(cmd);
 
 	//string tmp_file = tmp_dir + "/contig_tmp_" + "r" + int2str(round) + ".fasta";
 	//string line;
@@ -1049,7 +1053,7 @@ void SRAssemblerMaster::remove_no_hit_contigs(int round){
 	//unordered_set<string> hits = aligner->get_hit_list(out_file);
 	remove_no_hit_contigs(out_file, round);
 	//string cmd = "rm -f " + tmp_dir + "/qindex*";
-	string cmd = "rm -f " + tmp_dir + "/cindex*";
+	string cmd = "rm -f " + tmp_dir + "/cindex* " + out_file;
 	logger->debug(cmd);
 	run_shell_command(cmd);
 }

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -928,7 +928,7 @@ void SRAssemblerMaster::remove_hit_contigs(vector<string> &contig_list, int roun
 void SRAssemblerMaster::remove_no_hit_contigs(const string& vmatch_outfile, int round){
 	logger->debug("remove contigs without hits against query sequences in round " + int2str(round));
 	string contig_file = get_contig_file_name(round);
-	string cmd = "bash -c \"vseqselect -seqnum " + vmatch_outfile + " " + tmp_dir + "/cindex\" | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' >> " + contig_file;
+	string cmd = "bash -c \"vseqselect -seqnum " + vmatch_outfile + " " + tmp_dir + "/cindex\" | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' > " + contig_file;
 	logger->debug(cmd);
 	run_shell_command(cmd);
 

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -203,7 +203,6 @@ void SRAssemblerMaster::do_preprocessing(){
 		// File splitting is handled by the actual library. It does not seem to take file type into acount.
 		if (lib->get_paired_end() && mpiSize > 2){
 			send_code(1, ACTION_SPLIT, lib_index, 1, 0);
-//			system("sleep 0.5");
 			send_code(2, ACTION_SPLIT, lib_index, 2, 0);
 			mpi_receive(code_value, from);
 			mpi_receive(code_value, from);
@@ -225,7 +224,6 @@ void SRAssemblerMaster::do_preprocessing(){
 		} else {
 			if (lib->get_num_parts() < mpiSize){
 				for (part=1; part<=lib->get_num_parts(); part++){
-					//system("sleep 0.5");
 					send_code(part, ACTION_PRE_PROCESSING, lib_index, part, 0);
 				}
 				while(completed < lib->get_num_parts()){
@@ -235,7 +233,6 @@ void SRAssemblerMaster::do_preprocessing(){
 			}
 			else {
 				for (part=1;part<mpiSize;part++){
-					//system("sleep 0.5");
 					send_code(part, ACTION_PRE_PROCESSING, lib_index, part, 0);
 				}
 				while (completed < lib->get_num_parts()){
@@ -348,14 +345,12 @@ void SRAssemblerMaster::do_walking(){
 			// If not parallelized, start a new alignment every 1/2 second?
 			if (mpiSize == 1){
 				for (read_part=1; read_part<=lib.get_num_parts(); read_part++){
-//					sleep(0.5);
 					new_reads_count += do_alignment(round, lib_idx, read_part);
 				}
 			} else {
 				// If there are more split read files than processors
 				if (lib.get_num_parts() < mpiSize){
 					for (read_part=1; read_part<=lib.get_num_parts(); read_part++){
-//						sleep(0.5);
 						send_code(read_part, ACTION_ALIGNMENT, round, read_part, lib_idx);
 					}
 					while(completed < lib.get_num_parts()){
@@ -368,7 +363,6 @@ void SRAssemblerMaster::do_walking(){
 				// If there are fewer split read files than processors
 				} else {
 					for (read_part=1;read_part<mpiSize;read_part++){
-//						sleep(0.5);
 						send_code(read_part, ACTION_ALIGNMENT, round, read_part, lib_idx);
 					}
 					while (completed < lib.get_num_parts()){
@@ -605,7 +599,6 @@ int SRAssemblerMaster::do_assembly(int round) {
 	} else {
 		if (total_k < mpiSize-1){
 			for (i=1; i<=total_k; i++){
-//				sleep(0.5);
 				send_code(i, ACTION_ASSEMBLY, round, start_k + (i-1)*step_k, 0);
 			}
 			while(completed < total_k){
@@ -615,7 +608,6 @@ int SRAssemblerMaster::do_assembly(int round) {
 		}
 		else {
 			for (i=1;i<mpiSize;i++){
-//				sleep(0.5);
 				send_code(i, ACTION_ASSEMBLY, round, start_k + (i-1)*step_k, 0);
 			}
 			while(completed < total_k){
@@ -933,42 +925,6 @@ void SRAssemblerMaster::remove_no_hit_contigs(const string& vmatch_outfile, int 
 	run_shell_command(cmd);
 }
 
-void SRAssemblerMaster::remove_no_hit_contigs(unordered_set<string> &hit_list, int round){
-	logger->debug("remove contigs without hits against query sequences in round " + int2str(round));
-	string contig_file = get_contig_file_name(round);
-	string tmp_file = tmp_dir + "/contig_tmp_" + "r" + int2str(round) + ".fasta";
-	string line;
-	string header = "";
-	string seq = "";
-	ifstream contig_file_stream(contig_file.c_str());
-	ofstream tmp_file_stream(tmp_file.c_str());
-	bool hit_seq = false;
-	int contig_number = 0;
-	while (getline(contig_file_stream, line)){
-		if (line.substr(0,1) == ">"){
-			string contig_id = int2str(contig_number);
-			if (hit_seq) {
-				tmp_file_stream << ">" << header << endl << seq << endl;
-			}
-			header = line.substr(1);
-			hit_seq = (find(hit_list.begin(), hit_list.end(), contig_id) != hit_list.end());
-			seq = "";
-			contig_number++;
-		}
-		else
-			seq.append(line);
-	}
-	if (hit_seq)
-		tmp_file_stream << ">" << header << endl << seq << endl;
-	contig_file_stream.close();
-	tmp_file_stream.close();
-	string cmd = "cp " + tmp_file + " " + contig_file;
-	run_shell_command(cmd);
-	//RM HERE
-	cmd = "rm " + tmp_file;
-	run_shell_command(cmd);
-}
-
 void SRAssemblerMaster::prepare_final_contig_file(int round){
 	logger->debug("prepare final contig file of round " + int2str(round));
 	string contig_file = get_contig_file_name(round);
@@ -1054,9 +1010,8 @@ run_shell_command("cp " + contig_file + " " + contig_file + ".original");
 	string out_file = tmp_dir + "/query_contig.aln";
 run_shell_command("cp " + out_file + " " + out_file + ".round" + int2str(round));
 	aligner->do_alignment(tmp_dir + "/qindex", type, get_match_length(1), get_mismatch_allowed(1), contig_file, params, out_file);
-	unordered_set<string> hits = aligner->get_hit_list(out_file);
 	remove_no_hit_contigs(out_file, round);
-//	string cmd = "rm -f " + tmp_dir + "/qindex*";
+	//string cmd = "rm -f " + tmp_dir + "/qindex*";
 	string cmd = "rm -f " + tmp_dir + "/cindex*";
 	logger->debug(cmd);
 	run_shell_command(cmd);

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -877,8 +877,6 @@ void SRAssemblerMaster::process_long_contigs(int round, int k) {
 			}
 		}
 	}
-	//TODO Masking is happening before cleaning in cleaning rounds.
-	//mask_contigs(round);
 }
 
 void SRAssemblerMaster::remove_hit_contigs(vector<string> &contig_list, int round){
@@ -1040,6 +1038,7 @@ void SRAssemblerMaster::create_folders(){
 void SRAssemblerMaster::remove_no_hit_contigs(int round){
 	logger->info("Removing contigs without hits ...");
 	string contig_file = get_contig_file_name(round);
+run_shell_command("cp " + contig_file + " " + contig_file + ".original");
 	Aligner* aligner = get_aligner(round);
 	// Index contigs for easy extraction of hit contigs
 	aligner->create_index(tmp_dir + "/cindex", "dna", contig_file);

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -925,6 +925,14 @@ void SRAssemblerMaster::remove_hit_contigs(vector<string> &contig_list, int roun
 	run_shell_command(cmd);
 }
 
+void SRAssemblerMaster::remove_no_hit_contigs(const string& vmatch_outfile, int round) {
+	logger->debug("remove contigs without hits against query sequences in round " + int2str(round));
+	string contig_file = get_contig_file_name(round);
+	string cmd = "bash -c \"vseqselect -seqnum " + vmatch_outfile + " " + tmp_dir + "/cindex\" | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' > " + contig_file;
+	logger->debug(cmd);
+	run_shell_command(cmd);
+}
+
 void SRAssemblerMaster::remove_no_hit_contigs(unordered_set<string> &hit_list, int round){
 	logger->debug("remove contigs without hits against query sequences in round " + int2str(round));
 	string contig_file = get_contig_file_name(round);
@@ -1047,7 +1055,7 @@ run_shell_command("cp " + contig_file + " " + contig_file + ".original");
 run_shell_command("cp " + out_file + " " + out_file + ".round" + int2str(round));
 	aligner->do_alignment(tmp_dir + "/qindex", type, get_match_length(1), get_mismatch_allowed(1), contig_file, params, out_file);
 	unordered_set<string> hits = aligner->get_hit_list(out_file);
-	remove_no_hit_contigs(hits, round);
+	remove_no_hit_contigs(out_file, round);
 //	string cmd = "rm -f " + tmp_dir + "/qindex*";
 	string cmd = "rm -f " + tmp_dir + "/cindex*";
 	logger->debug(cmd);

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -387,6 +387,8 @@ void SRAssemblerMaster::do_walking(){
 				}
 			}
 		}
+		save_mapped_reads(round);
+
 
 		if (new_reads_count == 0) {
 			logger->info("The walking is terminated: No new reads found.");

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -9,11 +9,12 @@
 
 SRAssemblerMaster::SRAssemblerMaster() {
 	// TODO Auto-generated constructor stub
+	//cerr << "SRAssemblerMaster constructed." << endl ;
 }
 
-int SRAssemblerMaster::init(int argc, char * argv[], int rank, int mpiSize) {
+int SRAssemblerMaster::init(int argc, char * argv[], int rank, int mpiSize, const int start_time) {
 	string cmd;
-	int ret = SRAssembler::init(argc, argv, rank, mpiSize);
+	int ret = SRAssembler::init(argc, argv, rank, mpiSize, start_time);
 	if (ret == -1)
 		return ret;
 	if (!get_aligner(Aligner::PROTEIN_ALIGNER)->is_available()) return -1;
@@ -28,7 +29,7 @@ int SRAssemblerMaster::init(int argc, char * argv[], int rank, int mpiSize) {
 		cmd.append(argv[i]).append(" ");
 	}
 	logger->info(cmd);
-	//logger->info("Dump directory is " + dump_dir);
+	//logger->info("Dump directory is " + mem_dir);
 	output_header();
 	output_libraries();
 	get_query_list();
@@ -992,7 +993,7 @@ void SRAssemblerMaster::create_folders(){
 	run_shell_command(cmd);
 	cmd = "mkdir " + tmp_dir;
 	run_shell_command(cmd);
-	cmd = "mkdir " + dump_dir;
+	cmd = "mkdir " + mem_dir;
 	run_shell_command(cmd);
 }
 
@@ -1082,4 +1083,5 @@ void SRAssemblerMaster::remove_unmapped_reads(int round){
 
 SRAssemblerMaster::~SRAssemblerMaster() {
 	// TODO Auto-generated destructor stub
+	cerr << "SRAssemblerMaster destructed" << endl ;
 }

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -334,9 +334,13 @@ void SRAssemblerMaster::do_walking(){
 		logger->info("Starting round " + int2str(round) + " ...");
 		int new_reads_count = 0;
 
-		// Index the contigs in round 1 for the dnavsprot vmatch step
-		if (round == 1)
-			create_index(round);
+		// Index the query in round 1 for the dnavsprot vmatch step
+		if (round == 1) {
+			create_index(1);
+		} else {
+		// Mask the previous round's contigs for later searches
+			mask_contigs(round-1);
+		}
 
 		// For each library
 		for (unsigned lib_idx=0;lib_idx<this->libraries.size();lib_idx++){

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -1008,11 +1008,13 @@ run_shell_command("cp " + contig_file + " " + contig_file + ".original");
 	program_name += "_" + get_type(1) + "_vs_contig";
 	Params params = read_param_file(program_name);
 	string out_file = tmp_dir + "/query_contig.aln";
-run_shell_command("cp " + out_file + " " + out_file + ".round" + int2str(round));
 	aligner->do_alignment(tmp_dir + "/qindex", type, get_match_length(1), get_mismatch_allowed(1), contig_file, params, out_file);
+	string cmd = "cp " + out_file + " " + out_file + ".round" + int2str(round);
+	logger->debug(cmd);
+	run_shell_command(cmd);
 	remove_no_hit_contigs(out_file, round);
 	//string cmd = "rm -f " + tmp_dir + "/qindex*";
-	string cmd = "rm -f " + tmp_dir + "/cindex*";
+	cmd = "rm -f " + tmp_dir + "/cindex*";
 	logger->debug(cmd);
 	run_shell_command(cmd);
 }

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -997,6 +997,7 @@ void SRAssemblerMaster::create_folders(){
 
 void SRAssemblerMaster::remove_no_hit_contigs(int round){
 	logger->info("Removing contigs without hits ...");
+	string cmd;
 	string contig_file = get_contig_file_name(round);
 run_shell_command("cp " + contig_file + " " + contig_file + ".original");
 	Aligner* aligner = get_aligner(round);
@@ -1007,11 +1008,14 @@ run_shell_command("cp " + contig_file + " " + contig_file + ".original");
 	string program_name = aligner->get_program_name();
 	program_name += "_" + get_type(1) + "_vs_contig";
 	Params params = read_param_file(program_name);
-	string out_file = tmp_dir + "/query_contig.aln";
+	string out_file = tmp_dir + "/query_contig.round" + int2str(round) + ".aln";
+//	cmd = "rm " + out_file;
+//	logger->debug(cmd);
+//	run_shell_command(cmd);
 	aligner->do_alignment(tmp_dir + "/qindex", type, get_match_length(1), get_mismatch_allowed(1), contig_file, params, out_file);
-	string cmd = "cp " + out_file + " " + out_file + ".round" + int2str(round);
-	logger->debug(cmd);
-	run_shell_command(cmd);
+//	cmd = "cp " + out_file + " " + out_file + ".round" + int2str(round);
+//	logger->debug(cmd);
+//	run_shell_command(cmd);
 	remove_no_hit_contigs(out_file, round);
 	//string cmd = "rm -f " + tmp_dir + "/qindex*";
 	cmd = "rm -f " + tmp_dir + "/cindex*";

--- a/src/SRAssemblerMaster.cpp
+++ b/src/SRAssemblerMaster.cpp
@@ -179,7 +179,6 @@ void SRAssemblerMaster::do_preprocessing(){
 		if (file_exists(lib->get_split_file_name(1, LEFT_READ))){
 			//long library_read_count = get_read_count(lib->get_left_read(), lib->get_format()) + get_read_count(lib->get_right_read(), lib->get_format());
 			long split_read_count = count_preprocessed_reads(lib_index);
-			split_read_count /= 2; // Don't count header lines
 			logger->debug("split_read_count: " + int2str(split_read_count));
 			lib->set_num_parts(get_file_count(data_dir + "/lib" + int2str(lib_index+1) + "/" + get_file_base_name(lib->get_left_read()) + "_*." + "fasta"));
 			// Test if split reads have been indexed
@@ -416,11 +415,13 @@ void SRAssemblerMaster::do_walking(){
 				logger->info("The walking is terminated: No contigs found.");
 				break;
 			}
+			// If maximum round is reached, stop
 			logger->info("Round " + int2str(round) + " is done!");
 			if (round == num_rounds) {
 				logger->info("The walking is terminated: The maximum round (" + int2str(num_rounds) + ") has been reached.");
 				break;
 			}
+			// If we haven't yet found a contig that meets the required length
 			if (longest_contig < min_contig_lgth) {
 				assembly_round = round + 1;
 				//RM HERE

--- a/src/SRAssemblerMaster.h
+++ b/src/SRAssemblerMaster.h
@@ -26,7 +26,6 @@ private:
 	void prepare_final_contig_file(int round);
 	void remove_hit_contigs(vector<string> &contig_list, int round);
 	void remove_no_hit_contigs(const string& vmatch_outfile, int round);
-	void remove_no_hit_contigs(unordered_set<string> &contig_list, int round);
 	void remove_no_hit_contigs(int round);
 	int get_start_round();
 	void load_long_contigs();

--- a/src/SRAssemblerMaster.h
+++ b/src/SRAssemblerMaster.h
@@ -30,7 +30,8 @@ private:
 	int get_start_round();
 	void load_long_contigs();
 	void remove_contigs_no_hits(int round);
-	void clean_unmapped_reads(int round);
+	void remove_unmapped_reads_VMATCH(int round);
+	void remove_unmapped_reads(int round);
 	void clean_tmp_files(int round);
 	void create_folders();
 	void save_query_list();

--- a/src/SRAssemblerMaster.h
+++ b/src/SRAssemblerMaster.h
@@ -25,12 +25,10 @@ private:
 	void process_long_contigs(int round, int k);
 	void prepare_final_contig_file(int round);
 	void remove_hit_contigs(vector<string> &contig_list, int round);
-	void remove_no_hit_contigs(const string& vmatch_outfile, int round);
 	void remove_no_hit_contigs(int round);
 	int get_start_round();
 	void load_long_contigs();
 	void remove_contigs_no_hits(int round);
-	void remove_unmapped_reads_VMATCH(int round);
 	void remove_unmapped_reads(int round);
 	void clean_tmp_files(int round);
 	void create_folders();

--- a/src/SRAssemblerMaster.h
+++ b/src/SRAssemblerMaster.h
@@ -14,7 +14,7 @@
 class SRAssemblerMaster: public SRAssembler {
 public:
 	SRAssemblerMaster();
-	int init(int argc, char * argv[], int rank, int mpiSize);
+	int init(int argc, char * argv[], int rank, int mpiSize, const int start_time);
 	void show_usage();
 	void print_message(const string&);
 	int do_assembly(int round);

--- a/src/SRAssemblerMaster.h
+++ b/src/SRAssemblerMaster.h
@@ -25,6 +25,7 @@ private:
 	void process_long_contigs(int round, int k);
 	void prepare_final_contig_file(int round);
 	void remove_hit_contigs(vector<string> &contig_list, int round);
+	void remove_no_hit_contigs(const string& vmatch_outfile, int round);
 	void remove_no_hit_contigs(unordered_set<string> &contig_list, int round);
 	void remove_no_hit_contigs(int round);
 	int get_start_round();

--- a/src/SRAssemblerMaster.h
+++ b/src/SRAssemblerMaster.h
@@ -25,7 +25,7 @@ private:
 	void process_long_contigs(int round, int k);
 	void prepare_final_contig_file(int round);
 	void remove_hit_contigs(vector<string> &contig_list, int round);
-	void remove_no_hit_contigs(unordered_set<string> &contig_list, int round);
+	void remove_no_hit_contigs(const string& vmatch_outfile, int round);
 	void remove_no_hit_contigs(int round);
 	int get_start_round();
 	void load_long_contigs();

--- a/src/SRAssemblerSlave.cpp
+++ b/src/SRAssemblerSlave.cpp
@@ -50,6 +50,7 @@ void SRAssemblerSlave::process_message(){
 			break;
 		}
 		if (action == ACTION_TOTAL_PARTS){    //action terminated
+			//cerr << "I'm an SRAssemblerSlave who just got action=" + int2str(action) + " and value1 " + int2str(value1) + " and value2 " + int2str(value2) + " and value3 " + int2str(value3) << endl;
 			this->libraries[value1].set_num_parts(value2);
 		}
 		if (action == ACTION_SPLIT){  //do_split

--- a/src/SRAssemblerSlave.cpp
+++ b/src/SRAssemblerSlave.cpp
@@ -12,8 +12,8 @@ SRAssemblerSlave::SRAssemblerSlave() {
 
 }
 
-int SRAssemblerSlave::init(int argc, char * argv[], int rank, int mpiSize) {
-	return SRAssembler::init(argc, argv, rank, mpiSize);
+int SRAssemblerSlave::init(int argc, char * argv[], int rank, int mpiSize, const int start_time) {
+	return SRAssembler::init(argc, argv, rank, mpiSize, start_time);
 }
 
 void SRAssemblerSlave::print_message(const string& msg){

--- a/src/SRAssemblerSlave.h
+++ b/src/SRAssemblerSlave.h
@@ -13,7 +13,7 @@
 class SRAssemblerSlave: public SRAssembler {
 public:
 	SRAssemblerSlave();
-	int init(int argc, char * argv[], int rank, int mpiSize);
+	int init(int argc, char * argv[], int rank, int mpiSize, const int start_time);
 	void show_usage();
 	void print_message(const string&);
 	void do_preprocessing();

--- a/src/SnapGeneFinder.cpp
+++ b/src/SnapGeneFinder.cpp
@@ -16,7 +16,7 @@ SnapGeneFinder::~SnapGeneFinder() {
 	// TODO Auto-generated destructor stub
 }
 
-void SnapGeneFinder::do_gene_finding(const string& genomic_file, const string& species, const Params& params, const string& output_file){
+void SnapGeneFinder::do_gene_finding(const string& genomic_file, const string& species, const Params& params, const string& output_file, const string& protein_output_file){
 	string param_list = "";
 	string hmm = "";
 	for ( Params::const_iterator it = params.begin(); it != params.end(); ++it ){
@@ -24,7 +24,7 @@ void SnapGeneFinder::do_gene_finding(const string& genomic_file, const string& s
 			hmm = it->second;
 		param_list += " -" + it->first + " " + it->second;
 	}
-	string cmd = "snap " + hmm + " " + genomic_file + " -aa snap.predicted.prt > " + output_file + " 2>&1";
+	string cmd = "snap " + hmm + " " + genomic_file + " -aa " + protein_output_file + " > " + output_file + " 2>&1";
 	logger->debug(cmd);
 	run_shell_command(cmd);
 

--- a/src/SnapGeneFinder.h
+++ b/src/SnapGeneFinder.h
@@ -14,7 +14,7 @@ class SnapGeneFinder: public GeneFinder {
 public:
 	SnapGeneFinder(int, string);
 	virtual ~SnapGeneFinder();
-	void do_gene_finding(const string& genomic_file, const string& species, const Params& params, const string& output_file);
+	void do_gene_finding(const string& genomic_file, const string& species, const Params& params, const string& output_file, const string& protein_output_file);
 	string get_output_summary();
 	string get_program_name();
 	bool is_available();

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -92,20 +92,20 @@ void run_shell_command(const string& cmd) {
 
 string run_shell_command_with_return(const string& cmd)
 {
-  // setup
-  string data;
-  FILE *stream;
-  int buf_size = 2048;
-  char buffer[buf_size];
+	// setup
+	string data;
+	FILE *stream;
+	int buf_size = 2048;
+	char buffer[buf_size];
 
-  // do it
-  stream = popen(cmd.c_str(), "r");
-  while ( fgets(buffer, buf_size, stream) != NULL )
+	// do it
+	stream = popen(cmd.c_str(), "r");
+	while ( fgets(buffer, buf_size, stream) != NULL )
 	data.append(buffer);
-  pclose(stream);
+	pclose(stream);
 
-  // exit
-  return data;
+	// exit
+	return data;
 }
 
 int str2int (const string &str) {
@@ -173,8 +173,8 @@ long get_file_size(const string& filename) {
 }
 
 long get_read_count(const string& filename, int format) {
+	//TODO would this be faster using bash wc?
 	ifstream inFile(filename.c_str());
-	string read;
 	string line;
 	long line_count = 0;
 	while (getline(inFile,line)) {
@@ -225,43 +225,43 @@ string string_format(const string fmt, ...) {
 // Why isn't this set up for FASTA as well as FASTQ?
 void remove_duplicate_reads(const string& filename, int read_format) {
 	if (read_format == FORMAT_FASTA) {
-	    string tmp_file = filename + ".tmp";
-	    //TODO this does not return them in order
-	    string cmd = "awk '$0 ~ /^>/ && !seen[$0] {getline seq; seen[$0]=seq;} END {for (read in seen) {print read; print seen[read];}}' " + filename + " > " + tmp_file;
-	    run_shell_command(cmd);
-	    run_shell_command("cp " + tmp_file + " " + filename);
-	    run_shell_command("rm " + tmp_file);
+		string tmp_file = filename + ".tmp";
+		//TODO this does not return them in order
+		string cmd = "awk '$0 ~ /^>/ && !seen[$0] {getline seq; seen[$0]=seq;} END {for (read in seen) {print read; print seen[read];}}' " + filename + " > " + tmp_file;
+		run_shell_command(cmd);
+		run_shell_command("cp " + tmp_file + " " + filename);
+		run_shell_command("rm " + tmp_file);
 	}
 	//TODO make this more efficient as above, or possibly remove.
 	else {
-	    boost::unordered_set<string> mapped_reads;
-	    string tmp_file = filename + ".tmp";
-	    ifstream src_stream(filename.c_str());
-	    ofstream tmp_stream(tmp_file.c_str());
-	    string lead_chr = "@";
-	    string line;
-	    while (getline(src_stream, line)){
-		    if (line.substr(0,1) == lead_chr){
-			    if (mapped_reads.find(line) == mapped_reads.end()) {
-				    mapped_reads.insert(line);
-				    tmp_stream << line << endl;
-				    getline(src_stream, line);
-				    tmp_stream << line << endl;
-				    getline(src_stream, line);
-				    tmp_stream << line << endl;
-				    getline(src_stream, line);
-				    tmp_stream << line << endl;
-			    }
-			    else {
-				    getline(src_stream, line);
-				    getline(src_stream, line);
-				    getline(src_stream, line);
-			    }
-		    }
-	    }
-	    src_stream.close();
-	    tmp_stream.close();
-	    run_shell_command("cp " + tmp_file + " " + filename);
-	    run_shell_command("rm " + tmp_file);
-    }
+		boost::unordered_set<string> mapped_reads;
+		string tmp_file = filename + ".tmp";
+		ifstream src_stream(filename.c_str());
+		ofstream tmp_stream(tmp_file.c_str());
+		string lead_chr = "@";
+		string line;
+		while (getline(src_stream, line)){
+			if (line.substr(0,1) == lead_chr){
+				if (mapped_reads.find(line) == mapped_reads.end()) {
+					mapped_reads.insert(line);
+					tmp_stream << line << endl;
+					getline(src_stream, line);
+					tmp_stream << line << endl;
+					getline(src_stream, line);
+					tmp_stream << line << endl;
+					getline(src_stream, line);
+					tmp_stream << line << endl;
+				}
+				else {
+					getline(src_stream, line);
+					getline(src_stream, line);
+					getline(src_stream, line);
+				}
+			}
+		}
+		src_stream.close();
+		tmp_stream.close();
+		run_shell_command("cp " + tmp_file + " " + filename);
+		run_shell_command("rm " + tmp_file);
+	}
 }

--- a/src/VmatchAligner.cpp
+++ b/src/VmatchAligner.cpp
@@ -51,6 +51,10 @@ unordered_set<string> VmatchAligner::get_hit_list(const string& output_file) {
  */
 int VmatchAligner::parse_output(const string& output_file, unordered_set<string>& mapped_reads, int read_part, const string& left_read_index, const string& right_read_index, const string& out_left_read, const string& out_right_read) {
 	logger->debug("parsing output file " + output_file);
+	std::cerr << "mapped_reads size = " << mapped_reads.size() << std::endl;
+	std::cerr << "mapped_reads bucket_count = " << mapped_reads.bucket_count() << std::endl;
+	std::cerr << "mapped_reads load_factor = " << mapped_reads.load_factor() << std::endl;
+	std::cerr << "mapped_reads max_load_factor = " << mapped_reads.max_load_factor() << std::endl;
 	bool paired_end = (out_right_read != "");
 	ifstream report_file_stream(output_file.c_str());
 	int found_new_read = 0;

--- a/src/VmatchAligner.cpp
+++ b/src/VmatchAligner.cpp
@@ -114,6 +114,9 @@ void VmatchAligner::create_index(const string& index_name, const string& type, c
 	run_shell_command(cmd);
 }
 
+/* This function APPENDS the sequence numbers of hits (usually reads) to the output_file.
+ * This is suitable input for vseqselect to pull those hits out of the mkvtree index.
+ */
 void VmatchAligner::do_alignment(const string& index_name, const string& type, int match_length, int mismatch_allowed, const string& query_file, const Params& params, const string& output_file) {
 	// Is this a protein query (round 1 only)? If not, empty string.
 	string align_type = (type == "protein") ? "-dnavsprot 1": "";
@@ -138,7 +141,9 @@ void VmatchAligner::do_alignment(const string& index_name, const string& type, i
 	}
 	string cmd;
 	string tmpvmfile = output_file + "-tmp";
-	// Vmatch output is appended to the output file so that left and right read searches for one part go into the same output file:
+	/* Vmatch output is appended to the output file so that left and right read searches for one part go into the same output file.
+	 * AWK selects only the column containing the sequence number. It is different for proteins because the reads are used as queries.
+	 */
 	if (type == "protein" ) {
 		cmd = "vmatch " + align_type + " -q " + query_file + " -d" + " -l " + int2str(match_length) + " " + e_option + " " + param_list + " -nodist -noevalue -noscore -noidentity " + index_name + " | awk '$0 !~ /^#.*/ {print $6}' >> " + output_file + "; sort -nu " + output_file + " > " + tmpvmfile + "; \\mv " + tmpvmfile + " " + output_file;
 	} else if (type == "cdna" ) {

--- a/src/VmatchAligner.cpp
+++ b/src/VmatchAligner.cpp
@@ -52,8 +52,8 @@ unordered_set<string> VmatchAligner::get_hit_list(const string& output_file) {
  */
 int VmatchAligner::parse_output(const string& output_file, unordered_set<string>& mapped_reads, int read_part, const string& left_read_index, const string& right_read_index, const string& out_left_read, const string& out_right_read) {
 	logger->debug("parsing output file " + output_file);
-	logger->debug("mapped_reads size = " + int2str(mapped_reads.size()));
-	logger->debug("mapped_reads bucket_count = " + int2str(mapped_reads.bucket_count()));
+	//logger->debug("mapped_reads size = " + int2str(mapped_reads.size()));
+	//logger->debug("mapped_reads bucket_count = " + int2str(mapped_reads.bucket_count()));
 	//logger->debug("mapped_reads load_factor = " + int2str(mapped_reads.load_factor()));
 	//logger->debug("mapped_reads max_load_factor = " + int2str(mapped_reads.max_load_factor()));
 	bool paired_end = (out_right_read != "");
@@ -90,11 +90,11 @@ int VmatchAligner::parse_output(const string& output_file, unordered_set<string>
 	tmp_file_stream.close();
 
 	// Use awk to strip out linebreaks from within the sequence
-	cmd = "bash -c \"vseqselect -seqnum " + tmpvseqselectfile + " " + left_read_index + "\" | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' >> " + out_left_read;
+	cmd = "vseqselect -seqnum " + tmpvseqselectfile + " " + left_read_index + " | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' >> " + out_left_read;
 	logger->debug(cmd);
 	run_shell_command(cmd);
 	if (paired_end) {
-		cmd = "bash -c \"vseqselect -seqnum " + tmpvseqselectfile + " " + right_read_index + "\" | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' >> " + out_right_read;
+		cmd = "vseqselect -seqnum " + tmpvseqselectfile + " " + right_read_index + " | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' >> " + out_right_read;
 		logger->debug(cmd);
 		run_shell_command(cmd);
 	}
@@ -127,7 +127,7 @@ void VmatchAligner::do_alignment(const string& index_name, const string& type, i
 	// Other parameters are set up here.
 	string param_list = "";
 	for ( Params::const_iterator it = params.begin(); it != params.end(); ++it ){
-			// Is "-e" option handled here, or above? Something seems vestigial.
+			// Allowed number of mismatches may be handled by arguments or from params
 			if (it->first == "e") {
 				if (str2int(it->second) > 0){
 					e_option = " -e " + it->second;

--- a/src/VmatchAligner.cpp
+++ b/src/VmatchAligner.cpp
@@ -76,8 +76,6 @@ int VmatchAligner::parse_output(const string& output_file, unordered_set<string>
 			found_new_read += 1;
 			mapped_reads.insert(seq_id);
 			tmp_file_stream << seq_number << endl;
-		} else {
-			cerr << seq_number + " is not new" << endl;
 		}
 	}
 	report_file_stream.close();
@@ -92,7 +90,9 @@ int VmatchAligner::parse_output(const string& output_file, unordered_set<string>
 		logger->debug(cmd);
 		run_shell_command(cmd);
 	}
+	//TODO make this part of a cleanup function.
 	cmd = "\\rm " + tmpvseqselectfile;
+	logger->debug(cmd);
 	run_shell_command(cmd);
 
 	return found_new_read;

--- a/src/VmatchAligner.cpp
+++ b/src/VmatchAligner.cpp
@@ -76,6 +76,8 @@ int VmatchAligner::parse_output(const string& output_file, unordered_set<string>
 			found_new_read += 1;
 			mapped_reads.insert(seq_id);
 			tmp_file_stream << seq_number << endl;
+		} else {
+			cerr << seq_number + " is not new" << endl;
 		}
 	}
 	report_file_stream.close();

--- a/src/VmatchAligner.cpp
+++ b/src/VmatchAligner.cpp
@@ -51,25 +51,28 @@ unordered_set<string> VmatchAligner::get_hit_list(const string& output_file) {
  */
 int VmatchAligner::parse_output(const string& output_file, unordered_set<string>& mapped_reads, int read_part, const string& left_read_index, const string& right_read_index, const string& out_left_read, const string& out_right_read) {
 	logger->debug("parsing output file " + output_file);
-	std::cerr << "mapped_reads size = " << mapped_reads.size() << std::endl;
-	std::cerr << "mapped_reads bucket_count = " << mapped_reads.bucket_count() << std::endl;
-	std::cerr << "mapped_reads load_factor = " << mapped_reads.load_factor() << std::endl;
-	std::cerr << "mapped_reads max_load_factor = " << mapped_reads.max_load_factor() << std::endl;
+	logger->debug("mapped_reads size = " + mapped_reads.size());
+	logger->debug("mapped_reads bucket_count = " + mapped_reads.bucket_count());
+	logger->debug("mapped_reads load_factor = " + mapped_reads.load_factor());
+	logger->debug("mapped_reads max_load_factor = " + mapped_reads.max_load_factor());
 	bool paired_end = (out_right_read != "");
 	ifstream report_file_stream(output_file.c_str());
 	int found_new_read = 0;
 	// parse the output file and get the mapped reads have not found yet
 	string line;
 	string cmd;
+	part_string = int2str(read_part) //Calculate this once rather than over and over
 	string tmpvseqselectfile = out_left_read + "-tmp";
 	ofstream tmp_file_stream(tmpvseqselectfile.c_str());
 	//run_shell_command("touch " + tmpvseqselectfile);
 
 	while (getline(report_file_stream, line)) {
+		logger->debug("seq_number " + seq_number);
 		string seq_number = line;
-		string seq_id = int2str(read_part) + "," + seq_number;
+		string seq_id = part_string + "," + seq_number;
 		// boost::unordered_set.find() produces past-the-end pointer if a key isn't found
 		if (mapped_reads.find(seq_id) == mapped_reads.end()) {
+			logger->debug(seq_number + " is new");
 			found_new_read += 1;
 			mapped_reads.insert(seq_id);
 			tmp_file_stream << seq_number << endl;

--- a/src/VmatchAligner.cpp
+++ b/src/VmatchAligner.cpp
@@ -57,6 +57,7 @@ int VmatchAligner::parse_output(const string& output_file, unordered_set<string>
 	logger->debug("mapped_reads max_load_factor = " + int2str(mapped_reads.max_load_factor()));
 	bool paired_end = (out_right_read != "");
 	ifstream report_file_stream(output_file.c_str());
+	int found_read = 0;
 	int found_new_read = 0;
 	// parse the output file and get the mapped reads have not found yet
 	string line;
@@ -67,17 +68,19 @@ int VmatchAligner::parse_output(const string& output_file, unordered_set<string>
 	//run_shell_command("touch " + tmpvseqselectfile);
 
 	while (getline(report_file_stream, line)) {
+		found_read++;
 		string seq_number = line;
-		logger->debug("seq_number " + seq_number);
+		//logger->debug("seq_number " + seq_number);
 		string seq_id = part_string + "," + seq_number;
 		// boost::unordered_set.find() produces past-the-end pointer if a key isn't found
 		if (mapped_reads.find(seq_id) == mapped_reads.end()) {
-			logger->debug(seq_number + " is new");
+			//logger->debug(seq_number + " is new");
 			found_new_read += 1;
 			mapped_reads.insert(seq_id);
 			tmp_file_stream << seq_number << endl;
 		}
 	}
+	logger->debug("Found " + int2str(found_read) + " reads in part " + part_string);
 	report_file_stream.close();
 	tmp_file_stream.close();
 

--- a/src/VmatchAligner.cpp
+++ b/src/VmatchAligner.cpp
@@ -51,24 +51,24 @@ unordered_set<string> VmatchAligner::get_hit_list(const string& output_file) {
  */
 int VmatchAligner::parse_output(const string& output_file, unordered_set<string>& mapped_reads, int read_part, const string& left_read_index, const string& right_read_index, const string& out_left_read, const string& out_right_read) {
 	logger->debug("parsing output file " + output_file);
-	logger->debug("mapped_reads size = " + mapped_reads.size());
-	logger->debug("mapped_reads bucket_count = " + mapped_reads.bucket_count());
-	logger->debug("mapped_reads load_factor = " + mapped_reads.load_factor());
-	logger->debug("mapped_reads max_load_factor = " + mapped_reads.max_load_factor());
+	logger->debug("mapped_reads size = " + int2str(mapped_reads.size()));
+	logger->debug("mapped_reads bucket_count = " + int2str(mapped_reads.bucket_count()));
+	logger->debug("mapped_reads load_factor = " + int2str(mapped_reads.load_factor()));
+	logger->debug("mapped_reads max_load_factor = " + int2str(mapped_reads.max_load_factor()));
 	bool paired_end = (out_right_read != "");
 	ifstream report_file_stream(output_file.c_str());
 	int found_new_read = 0;
 	// parse the output file and get the mapped reads have not found yet
 	string line;
 	string cmd;
-	part_string = int2str(read_part) //Calculate this once rather than over and over
+	string part_string = int2str(read_part); //Calculate this once rather than over and over
 	string tmpvseqselectfile = out_left_read + "-tmp";
 	ofstream tmp_file_stream(tmpvseqselectfile.c_str());
 	//run_shell_command("touch " + tmpvseqselectfile);
 
 	while (getline(report_file_stream, line)) {
-		logger->debug("seq_number " + seq_number);
 		string seq_number = line;
+		logger->debug("seq_number " + seq_number);
 		string seq_id = part_string + "," + seq_number;
 		// boost::unordered_set.find() produces past-the-end pointer if a key isn't found
 		if (mapped_reads.find(seq_id) == mapped_reads.end()) {

--- a/src/VmatchAligner.cpp
+++ b/src/VmatchAligner.cpp
@@ -20,6 +20,7 @@ unordered_set<string> VmatchAligner::get_hit_list(const string& output_file) {
 	boost::unordered_set<string> current_mapped_reads;
 	string line;
 	while (getline(report_file_stream, line)) {
+	//TODO this could probably be more efficient
 		if (line[0] != '#') {
 			vector<string> tokens;
 			tokenize(line, tokens, " ");
@@ -88,6 +89,7 @@ int VmatchAligner::parse_output(const string& output_file, unordered_set<string>
 	report_file_stream.close();
 	tmp_file_stream.close();
 
+	// Use awk to strip out linebreaks from within the sequence
 	cmd = "bash -c \"vseqselect -seqnum " + tmpvseqselectfile + " " + left_read_index + "\" | awk '!/^>/ { printf \"%s\", $0; n = \"\\n\" } /^>/ { print n $0} END { printf n }' >> " + out_left_read;
 	logger->debug(cmd);
 	run_shell_command(cmd);
@@ -107,7 +109,7 @@ int VmatchAligner::parse_output(const string& output_file, unordered_set<string>
 void VmatchAligner::create_index(const string& index_name, const string& type, const string& fasta_file) {
 	string db_type = type;
 	if (db_type == "cdna") db_type = "dna";
-	string cmd = "mkvtree -" + db_type + " -db " + fasta_file + " -pl -indexname " + index_name + " -allout -v >> " + logger->get_log_file();
+	string cmd = "mkvtree -" + db_type + " -db " + fasta_file + " -pl -indexname " + index_name + " -allout >> " + logger->get_log_file();
 	logger->debug(cmd);
 	run_shell_command(cmd);
 }


### PR DESCRIPTION
Fixed the issue with losing good reads after cleaning by replacing the use of bowtie with more Vmatch. Use /dev/shm for the Vmatch output files, although this did not give much of a speed up, probably due to file caching. It's still arguably cleaner. I'm still seeing occasional SOAPdenovo Segfaults.